### PR TITLE
Potential fix for code scanning alert no. 9: Database query built from user-controlled sources

### DIFF
--- a/backend/src/controllers/orderController.ts
+++ b/backend/src/controllers/orderController.ts
@@ -87,7 +87,14 @@ export const getRestaurantOrders = async (
     const { id } = req.params;
     const { status, startDate, endDate } = req.query;
     const query: any = { restaurantId: id };
-    if (status) query.status = status;
+    const validStatuses = ["pending", "cooking", "ready", "served"]; // Define valid statuses
+    if (status) {
+      if (typeof status !== "string" || !validStatuses.includes(status)) {
+        res.status(400).json({ message: "Invalid status value" });
+        return;
+      }
+      query.status = status;
+    }
     if (startDate && endDate) {
       query.createdAt = {
         $gte: new Date(startDate as string),


### PR DESCRIPTION
Potential fix for [https://github.com/NexTechNomad/DineZap/security/code-scanning/9](https://github.com/NexTechNomad/DineZap/security/code-scanning/9)

To fix the issue, we need to ensure that the `status` parameter is validated and sanitized before being used in the MongoDB query. The best approach is to check that `status` is a literal value (e.g., a string) and not a query object or operator. This can be achieved by validating the type of `status` and ensuring it matches expected values.

Steps to implement the fix:
1. Validate the `status` parameter to ensure it is a string and matches expected values (e.g., predefined order statuses).
2. Reject the request with a `400 Bad Request` response if the validation fails.
3. Update the `query` object construction to use the validated `status` parameter.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
