### PR TITLE
Potential fix for code scanning alert no. 2: Database query built from user-controlled sources

### DIFF
--- a/backend/src/controllers/authController.ts
+++ b/backend/src/controllers/authController.ts
@@ -10,7 +10,12 @@ export const registerRestaurant = async (
   try {
     const { name, email, password, phone, address } = req.body;
 
-    const existingRestaurant = await Restaurant.findOne({ email });
+    if (typeof email !== "string" || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
+      res.status(400).json({ message: "Invalid email format" });
+      return;
+    }
+
+    const existingRestaurant = await Restaurant.findOne({ email: { $eq: email } });
     if (existingRestaurant) {
       res.status(400).json({ message: "Restaurant already exists" });
       return;


### PR DESCRIPTION
Potential fix for [https://github.com/NexTechNomad/DineZap/security/code-scanning/2](https://github.com/NexTechNomad/DineZap/security/code-scanning/2)

To fix the issue, we need to ensure that the `email` field is sanitized or validated before being used in the MongoDB query. The best approach is to use the `$eq` operator in the query to ensure that the `email` field is treated as a literal value. Additionally, we can validate the `email` field to ensure it is a string and matches a valid email format.

Changes to make:
1. Update the query on line 13 to use the `$eq` operator.
2. Add validation to ensure that `email` is a string and matches a valid email format before proceeding with the query.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
