### PR TITLE
Potential fix for code scanning alert no. 49: Database query built from user-controlled sources

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -46,7 +46,7 @@ app.post(
       const event = JSON.parse(req.body.toString());
       if (event.event === "charge.success") {
         const { reference, metadata } = event.data;
-        const restaurant = await Restaurant.findById(metadata.restaurantId);
+        const restaurant = await Restaurant.findOne({ _id: { $eq: metadata.restaurantId } });
         if (!restaurant) {
           res.status(404).json({ message: "Restaurant not found" });
           return;


### PR DESCRIPTION
Potential fix for [https://github.com/NexTechNomad/DineZap/security/code-scanning/49](https://github.com/NexTechNomad/DineZap/security/code-scanning/49)

To fix the issue, we need to ensure that `metadata.restaurantId` is interpreted as a literal value and not as a query object. This can be achieved by using MongoDB's `$eq` operator in the query. Alternatively, we can validate that `metadata.restaurantId` is a string before using it in the query. The `$eq` operator is the preferred approach as it directly addresses the NoSQL injection risk.

**Steps to implement the fix:**
1. Modify the query on line 49 to use the `$eq` operator, ensuring that `metadata.restaurantId` is treated as a literal value.
2. Optionally, add validation to check that `metadata.restaurantId` is a string before using it in the query.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
